### PR TITLE
Add crank filter for openbook routes

### DIFF
--- a/app/src/crank_client.ts
+++ b/app/src/crank_client.ts
@@ -200,7 +200,20 @@ export class CrankClient {
     if (!recentBlockhash) {
       return null;
     }
-    const bestRouteAmount = JSBI.toNumber(routes[0].otherAmountThreshold);
+
+    // filter openbook routes
+    let bestRoute;
+
+    for (let i=0; i<routes.length; i++) {
+      if (!routes[i].marketInfos[0].amm.isOpenbook) {
+        bestRoute = routes[i];
+      }
+    }
+    // if no other routes than openbook, skip
+    if (!bestRoute) {
+      return null;
+    }
+    const bestRouteAmount = JSBI.toNumber(bestRoute.otherAmountThreshold);
 
     for (const route of routes) {
       // check for approximate slippage


### PR DESCRIPTION
TWAMM cannot process Openbook routes. If openbook route is used, following error occurs.

```
Error: Signature verification failed
    at Transaction.serialize (twamm-crank/node_modules/@solana/web3.js/src/transaction/legacy.ts:775:13)
    at AnchorProvider.sendAndConfirm (twamm-crank/node_modules/@project-serum/anchor/src/provider.ts:146:22)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async MethodsBuilder.rpc [as _rpcFn] (twamm-crank/node_modules/@project-serum/anchor/src/program/namespace/rpc.ts:29:16)
```

While it does not kill the process, if Openbook continuously provides best route, crank would not be operational.

Following PR does
1. Loop computed routes
2. If `isOpenbook`, route is skipped. If not, route is assigned to`bestRoute`
3. If no routes are available other than Openbook, return `null`.